### PR TITLE
Added a check for the shodan API token

### DIFF
--- a/cmd/xray/main.go
+++ b/cmd/xray/main.go
@@ -1,28 +1,28 @@
 /*
- * Copyleft 2017, Simone Margaritelli <evilsocket at protonmail dot com>
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *   * Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *   * Neither the name of ARM Inject nor the names of its contributors may be used
- *     to endorse or promote products derived from this software without
- *     specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+* Copyleft 2017, Simone Margaritelli <evilsocket at protonmail dot com>
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+*   * Redistributions of source code must retain the above copyright notice,
+*     this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*   * Neither the name of ARM Inject nor the names of its contributors may be used
+*     to endorse or promote products derived from this software without
+*     specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
  */
 package main
 
@@ -84,10 +84,10 @@ func OnResult(res interface{}) {
 
 var (
 	session *xray.Session
-	pool   *xray.Pool
-	shapi  *shodan.Client
-	bruter *xray.Machine
-	router *gin.Engine
+	pool    *xray.Pool
+	shapi   *shodan.Client
+	bruter  *xray.Machine
+	router  *gin.Engine
 
 	base       = flag.String("domain", "", "Base domain to start enumeration from.")
 	wordlist   = flag.String("wordlist", "wordlists/default.lst", "Wordlist file to use for enumeration.")
@@ -101,13 +101,13 @@ var (
 func main() {
 	flag.Parse()
 
-	fmt.Println( "____  ___" )
-	fmt.Println( "\\   \\/  /" )
-	fmt.Println( " \\     RAY v", version )
-	fmt.Println( " /    by Simone 'evilsocket' Margaritelli" )
-	fmt.Println( "/___/\\  \\" )
-	fmt.Println( "      \\_/" )
-	fmt.Println( "" )
+	fmt.Println("____  ___")
+	fmt.Println("\\   \\/  /")
+	fmt.Println(" \\     RAY v", version)
+	fmt.Println(" /    by Simone 'evilsocket' Margaritelli")
+	fmt.Println("/___/\\  \\")
+	fmt.Println("      \\_/")
+	fmt.Println("")
 
 	if *base = domainutil.Domain(*base); *base == "" {
 		fmt.Println("Invalid or empty domain specified.")
@@ -115,10 +115,10 @@ func main() {
 		os.Exit(1)
 	} else if *shodan_tok == "" {
 		fmt.Printf("! WARNING: No Shodan API token provided, XRAY won't be able to get per-ip information.\n")
-	} 
-	
+	}
+
 	if *sesfile == xray.SessionDefaultFilename || *sesfile == "" {
-		*sesfile = xray.GetSessionFileName(*base )
+		*sesfile = xray.GetSessionFileName(*base)
 	}
 
 	gin.SetMode(gin.ReleaseMode)
@@ -128,6 +128,17 @@ func main() {
 	shapi = shodan.NewClient(nil, *shodan_tok)
 	bruter = xray.NewMachine(*consumers, *wordlist, session, DoRequest, OnResult)
 	router = gin.New()
+
+	// Test Shodan API
+	info, err := shapi.GetAPIInfo()
+	if *shodan_tok != "" && err != nil {
+		fmt.Println("Shodan Error:", err)
+		fmt.Println("Please fix error or remove `-shodan-key` flag")
+		os.Exit(1)
+	}
+	if *shodan_tok != "" && info.QueryCredits <= 0 {
+		fmt.Println("Warning: You have", info.QueryCredits, "query credits.")
+	}
 
 	// Easy stuff, serve static assets and JSON "API"
 	router.Use(static.Serve("/", NewBFS("ui")))
@@ -142,9 +153,9 @@ func main() {
 
 	// Let the user know where the session file is located.
 	if !pool.WasRestored() {
-		fmt.Printf( "@ Saving session to %s\n", *sesfile )
+		fmt.Printf("@ Saving session to %s\n", *sesfile)
 	} else {
-		fmt.Printf( "@ Restoring DNS bruteforcing from %.2f%%\n", session.Stats.Progress )
+		fmt.Printf("@ Restoring DNS bruteforcing from %.2f%%\n", session.Stats.Progress)
 	}
 
 	// Start web server in its own go routine.


### PR DESCRIPTION
I was having an issue and didn't know why the Shodan API wasn't working, so after digging into the code, I found that it wasn't connecting to my proxy.
The check that I added will help the user understand why their Shodan client is broken and give a check to make sure that if they do supply an API token, they have enough QueryCredits to do the `sh.GetServicesForHost`

My text editor automatically does `gofmt` to fix the spacing to keep it up to date with golang formatting standards. I can change this back to the original spacing, but it is typically preferred to use `gofmt`.