### PR TITLE
Added Dockerfile to allow a docker container to be built

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:alpine
+
+# Add git and make to alpine
+RUN apk add --no-cache git make
+
+# Download and install xray as per instructions
+RUN go get github.com/evilsocket/xray && \
+    cd $GOPATH/src/github.com/evilsocket/xray/ && \
+    make get_glide && \
+    make install_dependencies && \
+    go get -u github.com/jteeuwen/go-bindata/... && \
+    make build
+
+# Default port for xray
+EXPOSE 8080
+
+# Settings for run
+ENV PATH /go/src/github.com/evilsocket/xray/build/:$PATH
+
+# Build directory
+WORKDIR /go/src/github.com/evilsocket/xray/
+
+CMD ["xray"]

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ Example:
     @ Saving session to fbi.gov-xray-session.json
     @ Web UI running on http://127.0.0.1:8080/
 
+## Building a Docker image
+
+To build a Docker image with the latest version of XRay:
+
+    git clone github.com/evilsocket/xray
+    cd xray
+    docker build -t xraydocker .
+
+Once built, XRay can be started within a Docker container using the following:
+
+    docker run --rm -it -p 8080:8080 xraydocker xray -address 0.0.0.0 -domain example.com -shodan-key shodan_key_here
 
 ## License
 


### PR DESCRIPTION
As discussed in an earlier twitter conversation (https://twitter.com/_xpn_/status/884423477993897984), XRay works well in a docker image, specifically the base image "golang:alpine".

I've added a new "Dockerfile" to the root of the project to allow building XRay as a Docker image, and also updated README.md with instructions on how to build the image.

Note:

Currently I have the following docker hub image set up: https://hub.docker.com/r/xpnsec/xray/. 

This is pointing to my own Dockerfile in a repo at https://github.com/xpn/xray-docker. If this pull request is accepted, and the Dockerfile is added to the project, it may make sense to repoint the dockerhub build to this project and keep it self-contained.