### PR TITLE
fixes gofmt in Makefile to exclude vendor dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ NAME=xray
 SOURCE=cmd/$(NAME)/*.go
 GOBUILD=go build
 DEPEND=github.com/Masterminds/glide
+GOFILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 .PHONY: format
 format:
-	gofmt -s -w .
+	@gofmt -s -w $(GOFILES)
 
 # Command to get glide, you need to run it only once
 .PHONY: get_glide


### PR DESCRIPTION
This should resolve #27. gofmt should not format all files in vendor, just the project files (vendor files are not always properly formatted for gofmt :( )